### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/add-asana-comment.yml
+++ b/.github/workflows/add-asana-comment.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   link-asana-task:

--- a/.github/workflows/add-asana-comment.yml
+++ b/.github/workflows/add-asana-comment.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   link-asana-task:
     if: ${{ github.actor != 'dependabot[bot]' }}

--- a/.github/workflows/add-asana-comment.yml
+++ b/.github/workflows/add-asana-comment.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   link-asana-task:


### PR DESCRIPTION
Potential fix for [https://github.com/freckle/asana-hs/security/code-scanning/2](https://github.com/freckle/asana-hs/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's functionality, it likely needs `contents: read` to access repository contents and `pull-requests: write` to interact with pull requests. These permissions will be explicitly set to ensure the workflow operates securely and adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
